### PR TITLE
feat: add debian bullseye-slim to circumvent CVE-2024-21538 vulnerabi…

### DIFF
--- a/packages/cli/docker/Dockerfile.deb
+++ b/packages/cli/docker/Dockerfile.deb
@@ -1,0 +1,22 @@
+FROM node:bullseye-slim
+
+ARG version=latest
+
+RUN npm install -g @mockoon/cli@$version
+
+# Install packages using apt-get 
+RUN apt-get update && \
+    apt-get install -y curl tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+# (Optional) Set noninteractive to avoid tzdata config prompts
+# ENV DEBIAN_FRONTEND=noninteractive
+
+RUN adduser --shell /bin/sh --disabled-password --gecos "" mockoon
+USER mockoon
+
+EXPOSE 3000
+
+ENTRYPOINT ["mockoon-cli", "start", "--disable-log-to-file"]
+
+# Usage: docker run --mount type=bind,source="$(pwd)"/dataFile.json,target=/data,readonly -p <port>:<port> mockoon-test -d data


### PR DESCRIPTION
### Changes

1. Added a new Dockerfile to build from node:bullseye-slim instead of node:18-alpine.


### Reason for change
 The orginal base image node:18-alpine, has a vulnerability with cross-spawn 7.0.3 as documented in 

https://scout.docker.com/vulnerabilities/id/CVE-2024-21538?s=github&n=cross-spawn&t=npm&vr=%3E%3D7.0.0%2C%3C7.0.5&utm_source=desktop&utm_medium=ExternalLink

As this vulnerabilities severity is rated as `High`,  it cannot be used within my organisation, hence the need for an INTERIM image to use until the mockoon team have release a new version.

